### PR TITLE
Fix GeographicErr bug from navsat_transform node

### DIFF
--- a/include/robot_localization/navsat_transform.hpp
+++ b/include/robot_localization/navsat_transform.hpp
@@ -463,9 +463,9 @@ private:
   bool zero_altitude_;
 
   /**
-   * @brief True if the service setDatum has been called at least once, false otherwise
+   * @brief True if the service datum has been called at least once, false otherwise
    * 
-   * 
+   * If use_manual_datum_ is true and if set_datum_service_called_at_least_once_ is false, the NavSatFix messages are ignored 
   */
   bool set_datum_service_called_at_least_once_;
 

--- a/include/robot_localization/navsat_transform.hpp
+++ b/include/robot_localization/navsat_transform.hpp
@@ -463,6 +463,13 @@ private:
   bool zero_altitude_;
 
   /**
+   * @brief True if the service setDatum has been called at least once, false otherwise
+   * 
+   * 
+  */
+  bool set_datum_service_called_at_least_once;
+
+  /**
    * @brief Manual datum pose to be used by the transform computation
    *
    * Then manual datum requested by a service request (or configuration) is stored

--- a/include/robot_localization/navsat_transform.hpp
+++ b/include/robot_localization/navsat_transform.hpp
@@ -467,7 +467,7 @@ private:
    * 
    * 
   */
-  bool set_datum_service_called_at_least_once;
+  bool set_datum_service_called_at_least_once_;
 
   /**
    * @brief Manual datum pose to be used by the transform computation

--- a/src/navsat_transform.cpp
+++ b/src/navsat_transform.cpp
@@ -90,7 +90,7 @@ NavSatTransform::NavSatTransform(const rclcpp::NodeOptions & options)
   world_frame_id_("odom"),
   yaw_offset_(0.0),
   zero_altitude_(false),
-  set_datum_service_called_at_least_once(false)
+  set_datum_service_called_at_least_once_(false)
 {
   tf_buffer_ = std::make_unique<tf2_ros::Buffer>(this->get_clock());
   tf_listener_ = std::make_unique<tf2_ros::TransformListener>(*tf_buffer_);
@@ -256,7 +256,7 @@ void NavSatTransform::computeTransform()
   // that the base frame and world frame names can be set before
   // the manual datum pose is set. This must be done prior to the transform computation.
   // 
-  if (!transform_good_ && has_transform_odom_ && use_manual_datum_ && set_datum_service_called_at_least_once) {
+  if (!transform_good_ && has_transform_odom_ && use_manual_datum_ && set_datum_service_called_at_least_once_) {
     setManualDatum();
     RCLCPP_INFO(
       this->get_logger(), "Setting manual datum");
@@ -382,7 +382,7 @@ bool NavSatTransform::datumCallback(
   // we are using a datum from now on, and we want other methods to not attempt
   // to transform the values we are specifying here.
   use_manual_datum_ = true;
-  set_datum_service_called_at_least_once = true; // We have received the datum, no need to wait for it anymore.
+  set_datum_service_called_at_least_once_ = true; // We have received the datum, no need to wait for it anymore.
   transform_good_ = false;
   return true;
 }
@@ -661,7 +661,7 @@ void NavSatTransform::gpsFixCallback(
     !std::isnan(msg->altitude) && !std::isnan(msg->latitude) &&
     !std::isnan(msg->longitude));
 
-  if (good_gps && set_datum_service_called_at_least_once) {
+  if (good_gps && set_datum_service_called_at_least_once_) {
     // If we haven't computed the transform yet, then
     // store this message as the initial GPS data to use
     if (!transform_good_ && !use_manual_datum_) {

--- a/src/navsat_transform.cpp
+++ b/src/navsat_transform.cpp
@@ -258,8 +258,6 @@ void NavSatTransform::computeTransform()
   // 
   if (!transform_good_ && has_transform_odom_ && use_manual_datum_ && set_datum_service_called_at_least_once_) {
     setManualDatum();
-    RCLCPP_INFO(
-      this->get_logger(), "Setting manual datum");
   }
 
   // Only do this if:
@@ -389,8 +387,6 @@ bool NavSatTransform::datumCallback(
 
 void NavSatTransform::setManualDatum()
 {
-  RCLCPP_INFO(
-    this->get_logger(), "setTransformGps from setManualDatum");
   sensor_msgs::msg::NavSatFix fix;
   fix.latitude = manual_datum_geopose_.position.latitude;
   fix.longitude = manual_datum_geopose_.position.longitude;

--- a/src/navsat_transform.cpp
+++ b/src/navsat_transform.cpp
@@ -380,7 +380,7 @@ bool NavSatTransform::datumCallback(
   // we are using a datum from now on, and we want other methods to not attempt
   // to transform the values we are specifying here.
   use_manual_datum_ = true;
-  set_datum_service_called_at_least_once_ = true; // We have received the datum, no need to wait for it anymore.
+  set_datum_service_called_at_least_once_ = true;
   transform_good_ = false;
   return true;
 }
@@ -663,8 +663,6 @@ void NavSatTransform::gpsFixCallback(
     // store this message as the initial GPS data to use
     if (!transform_good_ && !use_manual_datum_) {
       setTransformGps(msg);
-        RCLCPP_INFO(
-    this->get_logger(), "setTransformGps from gpsFixCallback");
     }
 
     double cartesian_x = 0;

--- a/src/navsat_transform.cpp
+++ b/src/navsat_transform.cpp
@@ -661,7 +661,8 @@ void NavSatTransform::gpsFixCallback(
     !std::isnan(msg->altitude) && !std::isnan(msg->latitude) &&
     !std::isnan(msg->longitude));
 
-  if (good_gps && set_datum_service_called_at_least_once_) {
+  // If we're using the manual datum, then we need to wait for the set_datum service to be called at least once
+  if (good_gps && ( set_datum_service_called_at_least_once_ || ! use_manual_datum_ )) {
     // If we haven't computed the transform yet, then
     // store this message as the initial GPS data to use
     if (!transform_good_ && !use_manual_datum_) {


### PR DESCRIPTION
The bug was caused by NavSatFix messages being processed before the datum was set by the /map_origin_setter node. 
Fixed ignoring NavSatFix messages before setting the map. 
Tested only using multiple bags data, but not on the real robot.